### PR TITLE
feat: make the row of a pod clickable

### DIFF
--- a/.changeset/clickable-pods-row.md
+++ b/.changeset/clickable-pods-row.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Made pod rows in PodsTable clickable — clicking anywhere on a row now opens the pod details drawer.

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { screen } from '@testing-library/react';
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
 import * as pod from './__fixtures__/pod.json';
 import * as crashingPod from './__fixtures__/crashing-pod.json';
 import { renderInTestApp } from '@backstage/test-utils';
@@ -177,4 +178,24 @@ describe('PodsTable', () => {
     expect(screen.getByText('Container: other-side-car')).toBeInTheDocument();
     expect(screen.getAllByText('CrashLoopBackOff')).toHaveLength(2);
   });
+
+  it('should have pointer cursor style on rows', async () => {
+    await renderInTestApp(<PodsTable pods={[pod as any]} />);
+
+    const row = screen.getByText('dice-roller-6c8646bfd-2m5hv').closest('tr');
+    expect(row).toHaveStyle({ cursor: 'pointer' });
+  });
+
+  it('should trigger the row button when clicking a non-button cell', async () => {
+    await renderInTestApp(<PodsTable pods={[pod as any]} />);
+
+    const row = screen.getByText('dice-roller-6c8646bfd-2m5hv').closest('tr')!;
+    const button = row.querySelector('button');
+    const clickSpy = jest.spyOn(button!, 'click');
+
+    fireEvent.click(screen.getByText('dice-roller-6c8646bfd-2m5hv'));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -185,7 +185,11 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
   return (
     <div style={tableStyle}>
       <Table
-        options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
+        options={{ paging: true, search: false, emptyRowsWhenPaging: false, rowStyle: { cursor: 'pointer' } }}
+        onRowClick={(event: React.MouseEvent) => {
+          if ((event?.target as HTMLElement)?.closest('button')) return;
+          (event?.target as HTMLElement)?.closest('tr')?.querySelector('button')?.click();
+        }}
         // It was observed that in some instances the pod drawer closes when new data (like CPU usage) is available and the table reloads.
         // Mapping the metadata UID to the tables ID fixes this problem.
         data={


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the plugin-kubernetes-react pod rows to be clickable to open the pod details.

With this PR (Entire Row is clickable):
<img width="900" height="453" alt="backstagepodrow" src="https://github.com/user-attachments/assets/cf8bc27c-afff-4d8e-85e1-94f21c19c50e" />


Current behavior (Pod name is clickable): 
<img width="900" height="453" alt="backstagecurrent" src="https://github.com/user-attachments/assets/b6ccaf6e-5d5b-44b2-8d7a-2d6d99581eb6" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
